### PR TITLE
Implement pipeline example with RPC and SSE

### DIFF
--- a/.github/workflows/cctl.yml
+++ b/.github/workflows/cctl.yml
@@ -1,0 +1,24 @@
+name: Casper 2.0-RC3 CCTL
+on: [push]
+jobs:
+  build_and_test:
+    runs-on: ubuntu-22.04
+    services:
+      casper-cctl:
+        image: koxu1996/casper-cctl:2.0-rc3
+        ports:
+          - 14101:14101 # RPC
+          - 21101:21101 # SSE
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test RPC - info_get_status call
+        run: >
+          curl --silent --location 'http://127.0.0.1:21101/rpc'
+          --header 'Content-Type: application/json'
+          --data '{"id": 1, "jsonrpc": "2.0", "method": "info_get_status", "params": []}'
+          | jq
+      - name: Test SSE - read stream for 5 seconds
+        continue-on-error: true
+        run: |
+          curl --silent --location http://127.0.0.1:14101/events --max-time 5
+          (($? != 28)) && { printf '%s\n' "Unexpected exit code"; exit 1; }


### PR DESCRIPTION
This PR introduces example pipeline running **Dockerized CCTL for Casper 2.0**. It might be used in the future in integration tests of this Rust SDK.

Both RPC and SSE [works](https://github.com/koxu1996/casper-rust-sdk/actions/runs/10180493433/job/28158480444):

![image](https://github.com/user-attachments/assets/de06712f-d7dc-4f16-8d8b-82996b14e579)

![image](https://github.com/user-attachments/assets/b0ab8b70-a2e4-48f1-9502-3d6777525283)

**NOTE:** Image is based on the [latest CCTL](https://github.com/casper-network/cctl/commit/03687b5470be145197c0c9a64ed075f233fea884), with [small persistence fix](https://github.com/koxu1996/cctl/blob/968b07be75c698b21a2dfd14cc37deb5882c4f51/persistence-2.0.patch) - you can see [source code here](https://github.com/koxu1996/cctl/blob/main-fork/README.md).